### PR TITLE
Add a silent option to environment constructor

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -97,10 +97,14 @@ mutable struct Env
     finalize_called::Bool
     attached_models::Int
 
-    function Env()
+    function Env(; output_flag::Int = 1)
         a = Ref{Ptr{Cvoid}}()
-        ret = GRBloadenv(a, C_NULL)
+        ret = GRBemptyenv(a)
         env = new(a[], false, 0)
+        _check_ret(env, ret)
+        ret = GRBsetintparam(env.ptr_env, GRB_INT_PAR_OUTPUTFLAG, output_flag)
+        _check_ret(env, ret)
+        ret = GRBstartenv(env.ptr_env) 
         finalizer(env) do e
             e.finalize_called = true
             if e.attached_models == 0

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -392,11 +392,11 @@ function MOI.empty!(model::Optimizer)
     model.env.attached_models += 1
     _check_ret(model, ret)
     # Reset the parameters in this new environment
-    for (name, value) in model.params
-        MOI.set(model, MOI.RawOptimizerAttribute(name), value)
-    end
     if model.silent
         MOI.set(model, MOI.Silent(), true)
+    end
+    for (name, value) in model.params
+        MOI.set(model, MOI.RawOptimizerAttribute(name), value)
     end
     model.needs_update = false
     model.objective_type = _SCALAR_AFFINE

--- a/test/MOI/MOI_callbacks.jl
+++ b/test/MOI/MOI_callbacks.jl
@@ -17,7 +17,7 @@ end
 
 const MOI = Gurobi.MOI
 
-const GRB_ENV = isdefined(Main, :GRB_ENV) ? Main.GRB_ENV : Gurobi.Env()
+const GRB_ENV = isdefined(Main, :GRB_ENV) ? Main.GRB_ENV : Gurobi.Env(output_flag=0)
 
 function callback_simple_model()
     model = Gurobi.Optimizer(GRB_ENV)

--- a/test/MOI/MOI_multiobjective.jl
+++ b/test/MOI/MOI_multiobjective.jl
@@ -16,7 +16,7 @@ end
 
 const MOI = Gurobi.MOI
 
-const GRB_ENV = isdefined(Main, :GRB_ENV) ? Main.GRB_ENV : Gurobi.Env()
+const GRB_ENV = isdefined(Main, :GRB_ENV) ? Main.GRB_ENV : Gurobi.Env(output_flag=0)
 
 function test_multiobjective()
     model = Gurobi.Optimizer(GRB_ENV)

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -36,7 +36,8 @@ function runtests()
     return
 end
 
-const GRB_ENV = isdefined(Main, :GRB_ENV) ? Main.GRB_ENV : Gurobi.Env()
+const GRB_ENV =
+    isdefined(Main, :GRB_ENV) ? Main.GRB_ENV : Gurobi.Env(output_flag=0)
 
 function test_runtests()
     model =
@@ -204,7 +205,7 @@ function test_MULTI_ENV_automatic_env_empty()
 end
 
 function test_MULTI_ENV_manual_finalize()
-    env = Gurobi.Env()
+    env = Gurobi.Env(output_flag=0)
     model = Gurobi.Optimizer(env)
     finalize(env)
     @test env.finalize_called

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using Test
 # re-use an existing environment in the module, or name the test function
 # `test_MULTI_ENV_xxx` to trap the specific Gurobi error indicating that an
 # environment could not be created.
-const GRB_ENV = Gurobi.Env()
+const GRB_ENV = Gurobi.Env(output_flag=0)
 
 @testset "MathOptInterface Tests" begin
     for file in readdir("MOI")


### PR DESCRIPTION
Set gurobi.env to use silent parameter for all invocations in the tests